### PR TITLE
Add github actions for image building & support for nginx proxy configuration in env variable

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,0 +1,45 @@
+name: "Publish"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+on:
+  push:
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+  
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build and push Docker image for Proxy
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: ./energysmart-proxy
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}-proxy
+          labels: ${{ steps.meta.outputs.labels }}-proxy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
     restart: always
   energysmart-proxy:
     build: ./energysmart-proxy
+    environment:
+      - PROXY_PASS_LOCATION=energysmart-bridge:8001
     ports:
       - "443:443"
     restart: always

--- a/energysmart-proxy/Dockerfile
+++ b/energysmart-proxy/Dockerfile
@@ -2,10 +2,10 @@ FROM nginx:1.24
 
 RUN apt-get update && apt-get install -y openssl
 
-COPY nginx.conf /etc/nginx/
+COPY nginx.conf.template .
 
 RUN openssl req  -nodes -new -x509 -sha1 -subj '/CN=energysmartwaterheater.com' -keyout /etc/nginx/energysmartwaterheater.com.key -out /etc/nginx/energysmartwaterheater.com.crt -days 3650
 
 EXPOSE 443/tcp
 
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["/bin/sh" , "-c" , "envsubst < /nginx.conf.template > /etc/nginx/nginx.conf && exec nginx -g 'daemon off;'"]

--- a/energysmart-proxy/nginx.conf
+++ b/energysmart-proxy/nginx.conf
@@ -17,7 +17,8 @@ events {
 stream {
     server {
         listen                443 ssl;
-        proxy_pass            energysmart-bridge:8001;
+        proxy_pass            192.168.0.241:8001;
+        resolver 192.168.0.1;
 
         ssl_certificate       /etc/nginx/energysmartwaterheater.com.crt;
         ssl_certificate_key   /etc/nginx/energysmartwaterheater.com.key;

--- a/energysmart-proxy/nginx.conf.template
+++ b/energysmart-proxy/nginx.conf.template
@@ -18,7 +18,6 @@ stream {
     server {
         listen                443 ssl;
         proxy_pass            192.168.0.241:8001;
-        resolver 192.168.0.1;
 
         ssl_certificate       /etc/nginx/energysmartwaterheater.com.crt;
         ssl_certificate_key   /etc/nginx/energysmartwaterheater.com.key;


### PR DESCRIPTION
So this adds github actions that auto publishes 2 images for each change one for the proxy, and one for the mono app. The one caveat and we make way to tweak this is that the branch name is used for all tags so master branch will produce an image called `master` and then `master-proxy`

On top of this I also added the ability to set the proxy pass location. I am not sure how widely used this will be but currently I am running both containers on unraid outside docker compose and internal routing by container name does not work. So this just gives some more flexibility